### PR TITLE
[BUG] Ensure param is a dict

### DIFF
--- a/burp2api.py
+++ b/burp2api.py
@@ -70,8 +70,8 @@ def process_tree(tree):
 # For checking if the input is a valid JSON string
 def is_json_param(param):
     try:
-        json.loads(param)  # Try to parse the parameter as JSON
-        return True
+        res = json.loads(param)  # Try to parse the parameter as JSON
+        return isinstance(res, dict)
     except ValueError:
         return False
 


### PR DESCRIPTION
Hello,

This PR aims to ensure that `param` is of type `dict`

I got a bug during an audit assessment. I can't share the XML file, but I used Burp `2024.10.2`.

```python
Traceback (most recent call last):
  File "/workspace/Burp2API/burp2api.py", line 177, in <module>
    openapi_json = json.dumps(convert_to_openapi(treeProcessed), indent=2)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/Burp2API/burp2api.py", line 129, in convert_to_openapi
    properties_dict = {key: {"type": "string"} for key in json.loads(param_name).keys()}
                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'int' object has no attribute 'keys'
```